### PR TITLE
added type `children` for props of RealViewportProvider.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,7 @@ const RealViewportScript = memo(({ prefix }: { prefix: string }) => {
 });
 
 type Props = {
+  children: React.ReactNode | Element;
   debounceResize?: boolean;
   variablesPrefix?: string;
 };


### PR DESCRIPTION
why this commit was needed well -

error `Type '{ children: Element; }' has no properties in common with type 'IntrinsicAttributes & Props'.ts` thrown by -
 ```
<RealViewportProvider>
    <Component {...pageProps} />
</RealViewportProvider>
```