### PR TITLE
Fix: Missing children prop in React.FC after React 18

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,12 +46,18 @@ const RealViewportScript = memo(({ prefix }: { prefix: string }) => {
   );
 });
 
+
+/**
+ *  After React 18 the type React.FC does not provide a children prop anymore,
+ *  therefore it is necessary to manually add the type using the helper 
+ *  React.PropsWithChildren or the prop 'children: React.ReactNode'
+ */
 type Props = {
   debounceResize?: boolean;
   variablesPrefix?: string;
 };
 
-const RealViewportProvider: React.FC<Props> = ({
+const RealViewportProvider: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   debounceResize = true,
   variablesPrefix = "",


### PR DESCRIPTION
I tried to use the package with React 18 which gave me a lint when using the RealViewportProvider since it's missing the children type (React.FC does no longer provide it). This should fix the issue and work with previous React versions as well.

![image](https://user-images.githubusercontent.com/78830288/184690914-8f402fd9-1d75-4a7d-bb09-e8830d7fb23a.png)
See [codesandbox](https://codesandbox.io/s/staging-haze-n58lcu?file=/pages/_app.tsx)