### PR TITLE
Update 'next' version on peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "next": "^12.1.0",
+    "next": ">=11",
     "react": "*",
     "react-dom": "*"
   },


### PR DESCRIPTION
Set minimum version after `next/script` was introduced (next 11). This should allow for next 13 & 14 to be used as well.